### PR TITLE
emulate nix's '<=' and '>=' operator behaviour on equal bolleans and …

### DIFF
--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -235,12 +235,20 @@ test("'<=' operator", () => {
   expect(nixrt.less_eq(1, 0)).toBe(false);
   expect(nixrt.less_eq(1, 1)).toBe(true);
   expect(nixrt.less_eq(1, 2)).toBe(true);
+
+  // This reproduces nix's observed behaviour
+  expect(nixrt.less_eq([true], [true])).toBe(true);
+  expect(nixrt.less_eq([null], [null])).toBe(true);
 });
 
 test("'>=' operator", () => {
   expect(nixrt.more_eq(1, 0)).toBe(true);
   expect(nixrt.more_eq(1, 1)).toBe(true);
   expect(nixrt.more_eq(1, 2)).toBe(false);
+
+  // This reproduces nix's observed behaviour
+  expect(nixrt.more_eq([true], [true])).toBe(true);
+  expect(nixrt.more_eq([null], [null])).toBe(true);
 });
 
 test("'>' operator", () => {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -213,7 +213,7 @@ export function less(lhs: any, rhs: any): boolean {
 }
 
 export function less_eq(lhs: any, rhs: any): boolean {
-  return !less(rhs, lhs);
+  return eq(lhs, rhs) || less(lhs, rhs);
 }
 
 export function more(lhs: any, rhs: any): boolean {
@@ -221,7 +221,7 @@ export function more(lhs: any, rhs: any): boolean {
 }
 
 export function more_eq(lhs: any, rhs: any): boolean {
-  return !less(lhs, rhs);
+  return eq(lhs, rhs) || more(lhs, rhs);
 }
 
 function _equalTypesLess(lhs: any, rhs: any): boolean {


### PR DESCRIPTION
…nulls